### PR TITLE
Add calculator feature

### DIFF
--- a/public/app/ec2pricing/controllers.js
+++ b/public/app/ec2pricing/controllers.js
@@ -40,7 +40,7 @@
     return self
   }])
 
-  ec2pricing.controller("ApplicationController", ["$scope", "pricingDataLoader", "displaySettings", "normalizedReservePrice", "periodMultiplier", function ($scope, pricingDataLoader, displaySettings, normalizedReservePrice, periodMultiplier) {
+  ec2pricing.controller("ApplicationController", ["$scope", "pricingDataLoader", "displaySettings", "normalizedReservePrice", "periodMultiplier", "focus", function ($scope, pricingDataLoader, displaySettings, normalizedReservePrice, periodMultiplier, focus) {
     $scope.reservationTypes = {
       "lightReservation": "light",
       "mediumReservation": "medium",
@@ -107,6 +107,7 @@
     $scope.loading = true
     $scope.instanceTypes = []
     $scope.percentLoaded = 0
+    $scope.focus = focus
 
     $scope.$watch(
       function () {

--- a/public/app/ec2pricing/controllers.js
+++ b/public/app/ec2pricing/controllers.js
@@ -33,6 +33,9 @@
     self.save = save
     self.load = load
     self.update = update
+    self.toJson = function () {
+      return angular.toJson(state)
+    }
     return self
   }])
 
@@ -101,7 +104,26 @@
     }
 
     $scope.loading = true
+    $scope.instanceTypes = []
     $scope.percentLoaded = 0
+
+    $scope.$watch(
+      function () {
+        return $scope.instanceTypes.reduce(function (result, instanceType) { return result + '+' + instanceType.quantity + '*' + instanceType.apiName }, displaySettings.toJson())
+      }, function () {
+        var sum = function(price) {
+          return $scope.instanceTypes.reduce(function (sum, instanceType) { return instanceType.quantity ? (sum + instanceType.quantity * price(instanceType)) : sum }, 0)
+        }
+        var totalOnDemandPrice = sum($scope.onDemandPrice)
+        var totalReservedPrice = sum($scope.reservedPrice)
+        $scope.total = {
+          onDemandPrice: totalOnDemandPrice,
+          reservedPrice: totalReservedPrice,
+          spotPrice: sum($scope.spotPrice),
+          emrPrice: sum($scope.emrPrice),
+          ebsOptimizedPrice: sum($scope.ebsOptimizedPrice),
+        }
+      })
 
     displaySettings.load().then(function () {
       pricingDataLoader.load().then(function (data) {

--- a/public/app/ec2pricing/controllers.js
+++ b/public/app/ec2pricing/controllers.js
@@ -5,6 +5,7 @@
 
   ec2pricing.factory("displaySettings", ["$q", "localStorage", function ($q, localStorage) {
     var state = {
+      calculator: false,
       region: "us-east-1",
       operatingSystem: "linux",
       reservationType: "partialUpfront",

--- a/public/app/ec2pricing/directives.js
+++ b/public/app/ec2pricing/directives.js
@@ -3,6 +3,16 @@
 
   var directives = angular.module("ec2pricing.directives")
 
+  directives.directive('focusOn', function() {
+    return function(scope, elem, attr) {
+      scope.$on('focusOn', function(e, name) {
+        if(name === attr.focusOn) {
+          elem[0].focus()
+        }
+      })
+    }
+  })
+
   directives.directive("sortableColumn", ["displaySettings", function (displaySettings) {
     return {
       restrict: "A",

--- a/public/app/ec2pricing/filters.js
+++ b/public/app/ec2pricing/filters.js
@@ -24,21 +24,25 @@
     }
   }])
 
-  filters.filter("price", ["displaySettings", "periodMultiplier", "normalizedReservePrice", function (displaySettings, periodMultiplier, normalizedReservePrice) {
+  filters.filter("price", function () {
     return function (input) {
-      if (input == null) {
+      if (isNaN(input) || input == null) {
         return "n/a"
+      } else {
+        return "$" + input.toFixed(3)
       }
-      var hourlyPrice = input
-      if (typeof input == "object" && ("yrTerm1" in input || "yrTerm1-effectiveHourly" in input)) {
-        hourlyPrice = normalizedReservePrice(input)
-      }
-      if (isNaN(hourlyPrice) || hourlyPrice == null) {
-        return "n/a"
-      }
-      return "$" + (hourlyPrice * periodMultiplier[displaySettings.period]).toFixed(3)
     }
-  }])
+  })
+
+  filters.filter("percent", function () {
+    return function (input) {
+      if (isNaN(input) || input == null) {
+        return "n/a"
+      } else {
+        return Math.round(100 * input) + "%";
+      }
+    }
+  })
 
   filters.filter("disks", [function () {
     var nbsp = "\u00A0"

--- a/public/app/ec2pricing/filters.js
+++ b/public/app/ec2pricing/filters.js
@@ -180,7 +180,19 @@
     }
     return function (input) {
       if (input) {
-        var sorted = input.slice().sort(sortFunctions[displaySettings.sortField] || sortFunctions["apiName"])
+        var sortFunction = sortFunctions[displaySettings.sortField] || sortFunctions["apiName"]
+        if (displaySettings.calculator) {
+          var wrapped = sortFunction
+          var before = displaySettings.sortAscending ? -1 : 1
+          sortFunction = function (a, b) {
+            if (a.quantity) {
+              return b.quantity ? wrapped(a, b) : before
+            } else {
+              return b.quantity ? -before : wrapped(a, b)
+            }
+          }
+        }
+        var sorted = input.slice().sort(sortFunction)
         if (!displaySettings.sortAscending) {
           sorted.reverse()
         }

--- a/public/app/ec2pricing/utils.js
+++ b/public/app/ec2pricing/utils.js
@@ -3,6 +3,14 @@
 
   var utils = angular.module("ec2pricing.utils")
 
+  utils.factory('focus', ['$rootScope', '$timeout', function ($rootScope, $timeout) {
+    return function(name) {
+      $timeout(function (){
+        $rootScope.$broadcast('focusOn', name)
+      })
+    }
+  }])
+
   utils.factory("jsonpLoader", ["$window", "$rootScope", "$q", function ($window, $rootScope, $q) {
     return function (url, callbackName) {
       var deferred = $q.defer()

--- a/public/index.html
+++ b/public/index.html
@@ -152,8 +152,8 @@
                 <td class="price visible-lg visible-md">{{total.ebsOptimizedPrice | price}}</td>
               </tr>
               <tr ng-class="{highlight: instanceType.highlighted}" ng-click="toggleInstanceTypeHighlight(instanceType)" ng-repeat="instanceType in instanceTypes | sortInstances">
-                <td class="quantity" ng-if="settings.calculator">
-                  <span><input type="number" ng-model="instanceType.quantity" focus-on="{{instanceType.apiName}}" ng-change="focus(instanceType.apiName)"></input></span>
+                <td class="quantity col-md-1" ng-if="settings.calculator">
+                  <span><input class="form-control" type="number" ng-model="instanceType.quantity" focus-on="{{instanceType.apiName}}" ng-change="focus(instanceType.apiName)"></input></span>
                 </td>
                 <td class="apiName">
                   <span class="hidden-lg hidden-md"><span class="label label-primary">{{instanceType.apiName | shortApiName}}</span></span>

--- a/public/index.html
+++ b/public/index.html
@@ -152,8 +152,8 @@
                 <td class="price visible-lg visible-md">{{total.ebsOptimizedPrice | price}}</td>
               </tr>
               <tr ng-class="{highlight: instanceType.highlighted}" ng-click="toggleInstanceTypeHighlight(instanceType)" ng-repeat="instanceType in instanceTypes | sortInstances">
-                <td class="quantity col-md-1" ng-if="settings.calculator">
-                  <span><input class="form-control" type="number" ng-model="instanceType.quantity" focus-on="{{instanceType.apiName}}" ng-change="focus(instanceType.apiName)"></input></span>
+                <td class="quantity col-sm-1" ng-if="settings.calculator">
+                  <input type="number" class="form-control" ng-model="instanceType.quantity" focus-on="{{instanceType.apiName}}" ng-change="focus(instanceType.apiName)"></input>
                 </td>
                 <td class="apiName">
                   <span class="hidden-lg hidden-md"><span class="label label-primary">{{instanceType.apiName | shortApiName}}</span></span>

--- a/public/index.html
+++ b/public/index.html
@@ -153,7 +153,7 @@
               </tr>
               <tr ng-class="{highlight: instanceType.highlighted}" ng-click="toggleInstanceTypeHighlight(instanceType)" ng-repeat="instanceType in instanceTypes | sortInstances">
                 <td class="quantity" ng-if="settings.calculator">
-                  <span><input name="whatever" type="number" ng-model="instanceType.quantity"></input></span>
+                  <span><input type="number" ng-model="instanceType.quantity" focus-on="{{instanceType.apiName}}" ng-change="focus(instanceType.apiName)"></input></span>
                 </td>
                 <td class="apiName">
                   <span class="hidden-lg hidden-md"><span class="label label-primary">{{instanceType.apiName | shortApiName}}</span></span>

--- a/public/index.html
+++ b/public/index.html
@@ -107,6 +107,7 @@
           <table class="prices table table-striped table-hover">
             <thead>
               <tr>
+                <th sortable-column name="quantity" title="Desired quantity">#</th>
                 <th sortable-column name="apiName" title="The API name" class="text-column">Name</th>
                 <th sortable-column name="cpus" class="visible-lg visible-md">CPUs</th>
                 <th sortable-column name="ram">RAM</th>
@@ -124,7 +125,30 @@
               </tr>
             </thead>
             <tbody>
+              <tr>
+                <td class="quantity">
+                </td>
+                <td class="apiName">
+                  Total
+                </td>
+                <td class="cpus visible-lg visible-md"></td>
+                <td class="ram">
+                </td>
+                <td class="disk">
+                </td>
+                <td class="networkPerformance visible-lg visible-md">
+                </td>
+                <td class="price visible-lg visible-md visible-sm">{{total.reservedPrice | price}}</td>
+                <td class="price visible-lg visible-md">{{(1 - total.reservedPrice / total.onDemandPrice) | percent}}</td>
+                <td class="price">{{total.onDemandPrice | price}}</td>
+                <td class="price">{{total.spotPrice | price}}</td>
+                <td class="price visible-lg visible-md">{{total.emrPrice | price}}</td>
+                <td class="price visible-lg visible-md">{{total.ebsOptimizedPrice | price}}</td>
+              </tr>
               <tr ng-class="{highlight: instanceType.highlighted}" ng-click="toggleInstanceTypeHighlight(instanceType)" ng-repeat="instanceType in instanceTypes | sortInstances">
+                <td class="quantity">
+                  <span><input name="whatever" type="number" ng-model="instanceType.quantity"></input></span>
+                </td>
                 <td class="apiName">
                   <span class="hidden-lg hidden-md"><span class="label label-primary">{{instanceType.apiName | shortApiName}}</span></span>
                   <span class="visible-lg visible-md"><span class="label label-primary">{{instanceType.apiName}}</span></span>

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,13 @@
             EC2 Pricing
           </a>
         </div>
-        <ul class="nav navbar-nav navbar-right">
+        <ul class="nav nav-pills navbar-nav navbar-right">
+          <li role="presentation" class="{{settings.calculator ? 'active' : ''}}">
+            <a href="#" ng-click="settings.update('calculator', !settings.calculator)">
+              <span class="glyphicon {{settings.calculator ? 'glyphicon-check' : 'glyphicon-unchecked'}}" aria-hidden="true"></span>
+              Calculator
+            </a>
+          </li>
           <li class="dropdown">
             <a class="dropdown-toggle" data-toggle="dropdown">{{settings.region}} <b class="caret"></b></a>
             <ul class="dropdown-menu">
@@ -107,7 +113,7 @@
           <table class="prices table table-striped table-hover">
             <thead>
               <tr>
-                <th sortable-column name="quantity" title="Desired quantity">#</th>
+                <th sortable-column name="quantity" title="Desired quantity" ng-if="settings.calculator">#</th>
                 <th sortable-column name="apiName" title="The API name" class="text-column">Name</th>
                 <th sortable-column name="cpus" class="visible-lg visible-md">CPUs</th>
                 <th sortable-column name="ram">RAM</th>
@@ -125,7 +131,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr>
+              <tr ng-if="settings.calculator">
                 <td class="quantity">
                 </td>
                 <td class="apiName">
@@ -146,7 +152,7 @@
                 <td class="price visible-lg visible-md">{{total.ebsOptimizedPrice | price}}</td>
               </tr>
               <tr ng-class="{highlight: instanceType.highlighted}" ng-click="toggleInstanceTypeHighlight(instanceType)" ng-repeat="instanceType in instanceTypes | sortInstances">
-                <td class="quantity">
+                <td class="quantity" ng-if="settings.calculator">
                   <span><input name="whatever" type="number" ng-model="instanceType.quantity"></input></span>
                 </td>
                 <td class="apiName">

--- a/public/index.html
+++ b/public/index.html
@@ -150,12 +150,12 @@
                 <td class="networkPerformance visible-lg visible-md">
                   {{instanceType.networkPerformance}}
                 </td>
-                <td class="price visible-lg visible-md visible-sm">{{instanceType.prices[settings.region][settings.reservationType][settings.operatingSystem] | price}}</td>
-                <td class="price visible-lg visible-md">{{reservedSavingsPercentage(instanceType)}}</td>
-                <td class="price">{{instanceType.prices[settings.region]["onDemand"][settings.operatingSystem] | price}}</td>
-                <td class="price">{{instanceType.prices[settings.region]["spot"][settings.operatingSystem] | price}}</td>
-                <td class="price visible-lg visible-md">{{instanceType.prices[settings.region]["other"]["emr"] | price}}</td>
-                <td class="price visible-lg visible-md">{{instanceType.prices[settings.region]["other"]["ebsOptimized"] | price}}</td>
+                <td class="price visible-lg visible-md visible-sm">{{reservedPrice(instanceType) | price}}</td>
+                <td class="price visible-lg visible-md">{{(1 - reservedPrice(instanceType) / onDemandPrice(instanceType)) | percent}}</td>
+                <td class="price">{{onDemandPrice(instanceType) | price}}</td>
+                <td class="price">{{spotPrice(instanceType) | price}}</td>
+                <td class="price visible-lg visible-md">{{emrPrice(instanceType) | price}}</td>
+                <td class="price visible-lg visible-md">{{ebsOptimizedPrice(instanceType) | price}}</td>
               </tr>
             </tbody>
           </table>

--- a/public/styles/styles.less
+++ b/public/styles/styles.less
@@ -56,13 +56,13 @@ nav.top-menu {
 
   }
 
-  .quantity, .cpus, .ram, .disk, .networkPerformance, .price {
+  .quantity input, .cpus, .ram, .disk, .networkPerformance, .price {
     text-align: right
   }
 
   .quantity {
-    input {
-      width: 2.5em;
+    input::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+      opacity: 1;
     }
   }
 }

--- a/public/styles/styles.less
+++ b/public/styles/styles.less
@@ -56,8 +56,14 @@ nav.top-menu {
 
   }
 
-  .cpus, .ram, .disk, .networkPerformance, .price {
+  .quantity, .cpus, .ram, .disk, .networkPerformance, .price {
     text-align: right
+  }
+
+  .quantity {
+    input {
+      width: 2.5em;
+    }
   }
 }
 

--- a/public/styles/styles.less
+++ b/public/styles/styles.less
@@ -56,11 +56,16 @@ nav.top-menu {
 
   }
 
-  .quantity input, .cpus, .ram, .disk, .networkPerformance, .price {
+  .quantity, .quantity input, .cpus, .ram, .disk, .networkPerformance, .price {
     text-align: right
   }
 
   .quantity {
+    input {
+      padding: 0;
+      margin: 0;
+      height: auto;
+    }
     input::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
       opacity: 1;
     }


### PR DESCRIPTION
This adds a simple overlay for computing price differences between different quantities of different instance types.

This accumulates the total column-per-column, producing n/a as soon as any of the included instances types lack enough information. For the savings column, the savings are computed from the aggregated reserved and on-demand prices.

This makes no attempt to summarize CPUs, RAM, Disk, or Network performance, as these numbers are not really directly comparable.